### PR TITLE
removed invisible char so linux can find the mono bin

### DIFF
--- a/ArbitesEto2/ArbitesEto2.Gtk2/bin/Debug/run-arbites.sh
+++ b/ArbitesEto2/ArbitesEto2.Gtk2/bin/Debug/run-arbites.sh
@@ -1,1 +1,1 @@
-﻿mono ArbitesEto2.Gtk2.exe
+mono ArbitesEto2.Gtk2.exe

--- a/ArbitesEto2/ArbitesEto2.Gtk2/bin/Release/run-arbites.sh
+++ b/ArbitesEto2/ArbitesEto2.Gtk2/bin/Release/run-arbites.sh
@@ -1,1 +1,1 @@
-﻿mono ArbitesEto2.Gtk2.exe
+mono ArbitesEto2.Gtk2.exe

--- a/ArbitesEto2/ArbitesEto2.Gtk2/run-arbites.sh
+++ b/ArbitesEto2/ArbitesEto2.Gtk2/run-arbites.sh
@@ -1,1 +1,1 @@
-﻿mono ArbitesEto2.Gtk2.exe
+mono ArbitesEto2.Gtk2.exe


### PR DESCRIPTION
There was an invisible character on before the mono call, i removed this, so linux is able to find the mono binary